### PR TITLE
fix: update X social link URL and aria-label

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -56,11 +56,11 @@ test.describe("Footer Social Links", () => {
       "https://www.linkedin.com/company/vibeops"
     );
 
-    const twitterLink = socialLinks.getByRole("link", { name: /twitter/i });
-    await expect(twitterLink).toBeVisible();
-    await expect(twitterLink).toHaveAttribute(
+    const xLink = socialLinks.getByRole("link", { name: /^x$/i });
+    await expect(xLink).toBeVisible();
+    await expect(xLink).toHaveAttribute(
       "href",
-      "https://twitter.com/vibeops"
+      "https://x.com/vibeops_ca"
     );
 
     const instagramLink = socialLinks.getByRole("link", { name: /instagram/i });

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -20,15 +20,15 @@ describe("Layout", () => {
       expect(linkedinLink).toHaveAttribute("target", "_blank");
       expect(linkedinLink).toHaveAttribute("rel", "noopener noreferrer");
 
-      // Check Twitter link
-      const twitterLink = screen.getByRole("link", { name: /twitter/i });
-      expect(twitterLink).toBeInTheDocument();
-      expect(twitterLink).toHaveAttribute(
+      // Check X link
+      const xLink = screen.getByRole("link", { name: /^x$/i });
+      expect(xLink).toBeInTheDocument();
+      expect(xLink).toHaveAttribute(
         "href",
-        "https://twitter.com/vibeops"
+        "https://x.com/vibeops_ca"
       );
-      expect(twitterLink).toHaveAttribute("target", "_blank");
-      expect(twitterLink).toHaveAttribute("rel", "noopener noreferrer");
+      expect(xLink).toHaveAttribute("target", "_blank");
+      expect(xLink).toHaveAttribute("rel", "noopener noreferrer");
 
       // Check Instagram link
       const instagramLink = screen.getByRole("link", { name: /instagram/i });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -225,11 +225,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 <Linkedin size={20} />
               </a>
               <a
-                href="https://twitter.com/vibeops"
+                href="https://x.com/vibeops_ca"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-[#00ffcc] transition-colors"
-                aria-label="Twitter"
+                aria-label="X"
               >
                 <Twitter size={20} />
               </a>


### PR DESCRIPTION
## Summary
- Updates X (formerly Twitter) link from `twitter.com/vibeops` to `x.com/vibeops_ca`
- Changes aria-label from "Twitter" to "X"
- Updates unit and e2e tests accordingly

## Test plan
- [x] Unit tests pass
- [x] E2E tests pass