### PR TITLE
fix: use www.vibeops.ca and remove static OG tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,23 +22,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
-    <!-- OpenGraph Meta -->
-    <meta property="og:title" content="VibeOps — Reportly" />
-    <meta
-      property="og:description"
-      content="Automated engineering report generation powered by VibeOps."
-    />
-    <meta property="og:type" content="website" />
-
-    <!-- OpenGraph Image (your horizontal black logo is best) -->
-    <meta property="og:image" content="/Logo-blk-hrzntl.jpeg" />
-
-    <!-- Twitter Cards -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@vibeops" />
-    <meta name="twitter:title" content="VibeOps Technologies" />
-    <meta name="twitter:description" content="Automated engineering report generation." />
-    <meta name="twitter:image" content="/Logo-blk-hrzntl.jpeg" />
+    <!-- OG/Twitter tags handled dynamically by react-helmet-async -->
   </head>
 
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,4 +13,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://vibeops.ca/sitemap.xml
+Sitemap: https://www.vibeops.ca/sitemap.xml

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -10,7 +10,7 @@ interface SEOProps {
 }
 
 const SITE_NAME = 'VibeOps Technologies';
-const SITE_URL = 'https://vibeops.ca';
+const SITE_URL = 'https://www.vibeops.ca';
 const DEFAULT_OG_IMAGE = '/Logo-blk-hrzntl.jpeg';
 
 export function SEO({

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -25,7 +25,7 @@ export default function Blog() {
       <SEO
         title="Blog - Lab Notes"
         description="Practical examples, implementation notes, and experiments from VibeOps prototypes, estimators, and automation tests."
-        canonical="https://vibeops.ca/blog"
+        canonical="https://www.vibeops.ca/blog"
       />
       <div className="pt-24">
         {/* Hero */}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -55,7 +55,7 @@ export default function BlogPost() {
       <SEO
         title={post.title}
         description={post.metaDescription}
-        canonical={`https://vibeops.ca/blog/${slug}`}
+        canonical={`https://www.vibeops.ca/blog/${slug}`}
         ogType="article"
         ogImage={post.ogImage}
       />

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -284,7 +284,7 @@ export default function CaseStudies() {
       <SEO
         title="Case Studies"
         description="Client outcomes and portfolio projects. See how teams use VibeOps to automate workflows and build custom engineering software."
-        canonical="https://vibeops.ca/case-studies"
+        canonical="https://www.vibeops.ca/case-studies"
       />
       <div className="pt-24">
         {/* Hero */}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -178,7 +178,7 @@ export default function Contact() {
       <SEO
         title="Contact"
         description="Get in touch with VibeOps. Book a strategy session or contact our team directly for engineering automation, custom software, and Reportly."
-        canonical="https://vibeops.ca/contact"
+        canonical="https://www.vibeops.ca/contact"
       />
       <div className="pt-24 pb-16 px-4 relative overflow-hidden">
         {/* Tech Grid Background */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,7 +17,7 @@ export default function Index() {
       <SEO
         title="VibeOps Technologies"
         description="Engineering automation for civil, construction, and infrastructure teams. We automate reporting and workflows so engineers can focus on engineering."
-        canonical="https://vibeops.ca/"
+        canonical="https://www.vibeops.ca/"
       />
       <div className="pt-20">
         <HeroSection />

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -10,7 +10,7 @@ export default function PrivacyPolicy() {
       <SEO
         title="Privacy Policy"
         description="VibeOps Technologies Inc. privacy policy. Learn how we collect, use, and protect your personal information."
-        canonical="https://vibeops.ca/privacy"
+        canonical="https://www.vibeops.ca/privacy"
       />
       <div className="pt-24 pb-16">
         <Section>

--- a/src/pages/Reportly.tsx
+++ b/src/pages/Reportly.tsx
@@ -28,7 +28,7 @@ export default function Reportly() {
       <SEO
         title="Reportly"
         description="Automated engineering report generation. Transform hours of manual formatting into minutes. Works with your existing Word templates, generates charts and tables from live data."
-        canonical="https://vibeops.ca/reportly"
+        canonical="https://www.vibeops.ca/reportly"
       />
       <div className="relative">
         {/* Section 1: Hero */}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -68,7 +68,7 @@ export default function Services() {
       <SEO
         title="Services"
         description="Four types of engineering automation: Report Automation, Workflow Automation, Engineering Dashboards, and Internal Tools. Pick the one that solves your biggest bottleneck."
-        canonical="https://vibeops.ca/services"
+        canonical="https://www.vibeops.ca/services"
       />
       <div className="pt-24">
         {/* Hero */}

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -119,7 +119,7 @@ export default function Team() {
       <SEO
         title="Team"
         description="Meet the team building VibeOps. We build custom software for engineering and construction teams—reports, dashboards, field data tools, and internal applications."
-        canonical="https://vibeops.ca/team"
+        canonical="https://www.vibeops.ca/team"
       />
       <div className="pt-24">
         {/* Hero */}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -10,7 +10,7 @@ export default function Terms() {
       <SEO
         title="Terms of Service"
         description="VibeOps Technologies Inc. subscription agreement and terms of service. Governs access to and use of Reportly and other VibeOps services."
-        canonical="https://vibeops.ca/terms"
+        canonical="https://www.vibeops.ca/terms"
       />
       <div className="pt-24 pb-16">
         <Section>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ function sitemapPlugin(): Plugin {
   return {
     name: "generate-sitemap",
     closeBundle() {
-      const SITE_URL = "https://vibeops.ca";
+      const SITE_URL = "https://www.vibeops.ca";
 
       const staticRoutes = [
         "/",


### PR DESCRIPTION
## Summary
- Update all URLs to use `www.vibeops.ca` instead of `vibeops.ca` (matches Search Console property)
- Remove static OG/Twitter tags from index.html (now handled dynamically by react-helmet-async)

## Changes
- `index.html`: Removed static og:title, og:description, og:image, twitter:card, etc.
- `SEO.tsx`: Updated SITE_URL to `https://www.vibeops.ca`
- `vite.config.ts`: Updated sitemap SITE_URL to `https://www.vibeops.ca`
- `robots.txt`: Updated sitemap URL to `https://www.vibeops.ca/sitemap.xml`
- All page files: Updated canonical URLs to use www