### PR TITLE
feat(homepage): add investor LinkedIn post to press links

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,10 @@ const pressLinks = [
     label: "Venture Founder Cohort",
     url: "https://innovation.ubc.ca/news/february-02-2026/meet-51st-venture-founder-cohort",
   },
+  {
+    label: "Investor Spotlight",
+    url: "https://www.linkedin.com/feed/update/urn:li:share:7442251270310227970",
+  },
 ];
 
 const partnerLogos = [


### PR DESCRIPTION
## Summary
- Added investor's LinkedIn post to the "Trusted By & Featured In" press links section on the homepage

## Test plan
- [x] Verify "Investor Spotlight" link appears in the press links row on the homepage
- [x] Click the link and confirm it opens the correct LinkedIn post
- [x] Check mobile layout still renders cleanly with the additional link