### PR TITLE
feat(homepage): add Techcouver article to press links

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,10 @@ import { ScrambleText } from '@/components/ScrambleText';
 
 const pressLinks = [
   {
+    label: "Techcouver",
+    url: "https://techcouver.com/2026/03/30/ubc-ventures-take-stage-at-investor-showcase/",
+  },
+  {
     label: "UBC Investor Showcase",
     url: "https://innovation.ubc.ca/news/march-03-2026/meet-12-ubc-ventures-presenting-innovation-ubcs-2026-investor-showcase",
   },


### PR DESCRIPTION
## Summary
- Adds Techcouver article ["UBC Ventures Take Stage at Investor Showcase"](https://techcouver.com/2026/03/30/ubc-ventures-take-stage-at-investor-showcase/) to the homepage press links section

## Test plan
- [x] Verify the new link renders in the press section on the homepage
- [x] Confirm the link opens the correct Techcouver article