### PR TITLE
Blog: How AI is Transforming Civil Engineering Reporting (and Saving Engineers 30+ Hours a Week)

### DIFF
--- a/src/pages/blogs/ai-civil-engineering-reporting.mdx
+++ b/src/pages/blogs/ai-civil-engineering-reporting.mdx
@@ -1,0 +1,49 @@
+export const meta = {
+  title: "How AI is Transforming Civil Engineering Reporting (and Saving Engineers 30+ Hours a Week) | VibeOps Technologies",
+  description: "Learn how AI tools like Reportly are helping civil engineers automate reports, save time, and improve documentation quality.",
+  ogImage: "_No response_",
+}
+
+# How AI is Transforming Civil Engineering Reporting (and Saving Engineers 30+ Hours a Week)
+
+## Introduction
+Civil engineers are spending too much time on reports. From inspection logs to design summaries and compliance documents, reporting can take up **40–60% of an engineer’s week**. These tasks are essential but repetitive, time-consuming, and often frustrating. What if that time could be reduced to just a few hours? That is exactly what AI-powered tools like Reportly are solving.
+## The Problem with Traditional Reporting
+Engineering reporting today is:
+- Manual and repetitive
+- Prone to inconsistencies
+- Dependent on past templates and copy-paste workflows
+- Time-consuming under tight deadlines
+Even experienced engineers spend hours rewriting similar sections, formatting documents, and ensuring consistency. This is not where real engineering value is created.
+## How AI is Transforming Civil Engineering Workflows
+AI is shifting reporting from manual writing to **intelligent generation**. With AI-powered tools, engineers can:
+- Generate reports using past data and templates
+- Maintain consistency across all documentation
+- Reduce human error
+- Focus on analysis instead of formatting
+Instead of starting from scratch, engineers now start with **structured intelligence**.
+## What is Reportly?
+Reportly is an AI-powered tool designed specifically for civil engineers to automate reporting workflows. It works by:
+- Learning from your previous reports and templates
+- Generating structured, high-quality content instantly
+- Adapting to your company’s standards and formatting
+- Eliminating repetitive writing tasks
+**The result:** faster reports, better consistency, and more time for engineering work.
+## Real Impact: Time and Cost Savings
+AI-driven reporting delivers measurable results:
+1. Reports that took **6–8 hours** can now be completed in **1–2 hours**
+2. Weekly reporting workload drops significantly
+3. Teams deliver faster without sacrificing quality
+4. Firms reduce overhead tied to documentation
+This is not just efficiency, it is a **competitive advantage**.
+## Why This Matters for the Future of Engineering
+Firms that adopt AI early will:
+- Deliver projects faster
+- Improve documentation quality
+- Reduce operational costs
+- Enable engineers to focus on high-value problem solving
+AI will not replace engineers. It will **amplify their impact**.
+## Conclusion
+Civil engineering is evolving. The engineers and firms that succeed will not be the ones working longer hours but the ones using smarter tools. Reportly is built to help engineers move faster, reduce repetitive work, and focus on what truly matters.
+## Try Reportly
+Want to see how much time you can save? Visit: https://www.vibeops.ca/reportly


### PR DESCRIPTION
## New Blog Post

Closes #70

- **Title:** How AI is Transforming Civil Engineering Reporting (and Saving Engineers 30+ Hours a Week)
- **Slug:** `/blog/ai-civil-engineering-reporting`
- **Description:** Learn how AI tools like Reportly are helping civil engineers automate reports, save time, and improve documentation quality.

> Review the generated `.mdx` file, then merge to publish.